### PR TITLE
Adjust hiding of tram streets

### DIFF
--- a/res/scripts/lollo_street_tuning/postRunFnUtils.lua
+++ b/res/scripts/lollo_street_tuning/postRunFnUtils.lua
@@ -367,7 +367,7 @@ funcs.hideAllTramTracksStreets = function()
     -- print('_hideAllTramTracksStreets starting')
     local streetTypeFileNames = api.res.streetTypeRep.getAll()
     for streetTypeId, streetTypeFileName in pairs(streetTypeFileNames) do
-        if type(streetTypeId) == 'number' and streetTypeId > 0 then
+        if type(streetTypeId) == 'number' and streetTypeId > 0 and streetTypeFileName:starts("lollo") then
             local streetDataRecordFull = api.res.streetTypeRep.get(streetTypeId)
             -- print('working on streetID =', streetTypeId)
             if streetDataRecordFull ~= nil


### PR DESCRIPTION
Currently, the mod hides all streets that have only tram tracks (I suppose, dont know why). This affects other mods, for example the CommonAPI tram street package.

This small change adjusts the behavior such that only streets that start with "lollo" are hidden (which would cover all your mods if I  checked correctly).